### PR TITLE
vagrant: do not check for file existency

### DIFF
--- a/vagrant.go
+++ b/vagrant.go
@@ -69,11 +69,6 @@ func NewVagrant(path string) (*Vagrant, error) {
 
 // Create creates the vagrantFile in the pre initialized vagrant path.
 func (v *Vagrant) Create(vagrantFile string) error {
-	// if it's exists, don't overwrite anything and use the existing one
-	if err := v.vagrantfileExists(); err == nil {
-		return nil
-	}
-
 	return ioutil.WriteFile(v.vagrantfile(), []byte(vagrantFile), 0644)
 }
 


### PR DESCRIPTION
Overriding is more important as the user excepts to the create the file being passed. It should be the responsibility of the API user of checking an deleting the file. Otherwise we shouldn't mess up with it.
