### PR TITLE
vagrantutil: improve handling of Destroy / Status methods

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,0 +1,139 @@
+package vagrantutil
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/koding/logging"
+)
+
+type command struct {
+	log logging.Logger
+	cwd string
+
+	onSuccess func()
+	onFailure func(err error)
+
+	cmd *exec.Cmd
+}
+
+func newCommand(cwd string, log logging.Logger) *command {
+	cmd := &command{
+		cwd: cwd,
+	}
+
+	if log != nil {
+		cmd.log = log.New(cwd)
+	}
+
+	return cmd
+}
+
+func (cmd *command) init(args []string) {
+	cmd.cmd = exec.Command("vagrant", args...)
+	cmd.cmd.Dir = cmd.cwd
+
+	cmd.debugf("executing: %v", cmd.cmd.Args)
+}
+
+func (cmd *command) run(args ...string) (string, error) {
+	cmd.init(args)
+
+	out, err := cmd.cmd.CombinedOutput()
+	if err != nil {
+		if len(out) != 0 {
+			err = fmt.Errorf("%s: %s", err, out)
+		}
+
+		return "", cmd.done(err)
+	}
+
+	s := string(out)
+
+	cmd.debugf("execution of %v was successful: %s", cmd.cmd.Args, s)
+
+	return s, cmd.done(nil)
+
+}
+
+// start starts the command and sends back both the stdout and stderr to
+// the returned channel. Any error happened during the streaming is passed to
+// the Error field.
+func (cmd *command) start(args ...string) (ch <-chan *CommandOutput, err error) {
+	cmd.init(args)
+
+	stdoutPipe, err := cmd.cmd.StdoutPipe()
+	if err != nil {
+		return nil, cmd.done(err)
+	}
+
+	stderrPipe, err := cmd.cmd.StderrPipe()
+	if err != nil {
+		return nil, cmd.done(err)
+	}
+
+	if err := cmd.cmd.Start(); err != nil {
+		return nil, cmd.done(err)
+	}
+
+	var wg sync.WaitGroup
+	out := make(chan *CommandOutput)
+
+	output := func(r io.Reader) {
+		wg.Add(1)
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			cmd.debugf("%s", scanner.Text())
+
+			out <- &CommandOutput{Line: scanner.Text(), Error: nil}
+		}
+
+		if err := scanner.Err(); err != nil {
+			out <- &CommandOutput{Error: err}
+		}
+		wg.Done()
+	}
+
+	go output(stdoutPipe)
+	go output(stderrPipe)
+
+	go func() {
+		wg.Wait()
+		var err error
+		if err = cmd.cmd.Wait(); err != nil {
+			out <- &CommandOutput{Error: err}
+		}
+
+		close(out)
+		cmd.done(err)
+	}()
+
+	return out, nil
+}
+
+func (cmd *command) done(err error) error {
+	if err == nil {
+		if cmd.onSuccess != nil {
+			cmd.onSuccess()
+		}
+
+		return nil
+	}
+
+	cmd.debugf("execution of %v failed: %s", cmd.cmd.Args, err)
+
+	if cmd.onFailure != nil {
+		cmd.onFailure(err)
+	}
+
+	return err
+}
+
+func (cmd *command) debugf(format string, args ...interface{}) {
+	if cmd.log != nil {
+		cmd.log.Debug(format, args...)
+	}
+}

--- a/command.go
+++ b/command.go
@@ -80,10 +80,10 @@ func (cmd *command) start(args ...string) (ch <-chan *CommandOutput, err error) 
 	}
 
 	var wg sync.WaitGroup
+	wg.Add(2)
 	out := make(chan *CommandOutput)
 
 	output := func(r io.Reader) {
-		wg.Add(1)
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
 			cmd.debugf("%s", scanner.Text())

--- a/command.go
+++ b/command.go
@@ -36,7 +36,7 @@ func (cmd *command) init(args []string) {
 	cmd.cmd = exec.Command("vagrant", args...)
 	cmd.cmd.Dir = cmd.cwd
 
-	cmd.debugf("executing: %v", cmd.cmd.Args)
+	cmd.debugf("%s: executing: %v", cmd.cwd, cmd.cmd.Args)
 }
 
 func (cmd *command) run(args ...string) (string, error) {

--- a/error.go
+++ b/error.go
@@ -2,8 +2,20 @@ package vagrantutil
 
 import (
 	"errors"
+	"os"
 	"strings"
 )
+
+// List of errors ignored by Destroy / Status methods:
+const (
+	errNotCreated    = "A Vagrant environment or target machine is required to run this"
+	errRubyNotExists = "No such file or directory - getcwd (Errno::ENOENT)"
+)
+
+func isNotCreated(err error) bool {
+	return os.IsNotExist(err) || strings.Contains(err.Error(), errNotCreated) ||
+		strings.Contains(err.Error(), errRubyNotExists)
+}
 
 // The following errors are returned by the Wait function:
 var (

--- a/vagrant.go
+++ b/vagrant.go
@@ -159,6 +159,12 @@ func (v *Vagrant) Provider() (string, error) {
 // List returns all available boxes on the system. Under the hood it calls
 // "global-status" and parses the output.
 func (v *Vagrant) List() ([]*Vagrant, error) {
+	// Refresh box status cache. So it does not report that aborted
+	// box is running etc.
+	_, err := v.vagrantCommand().run("global-status", "--prune")
+	if err != nil {
+		return nil, err
+	}
 	out, err := v.vagrantCommand().run("global-status")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hey @fatih, 

In this PR I also address [this comment](https://github.com/koding/vagrantutil/pull/5#discussion_r57867968) by reworking process start/stop helpers to separate type; making it more decoupled would make it more testable.

Please take a look :-)

/cc @cihangir @sent-hil 
