### PR TITLE
Implement vagrant provision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/koding/vagrantutil
+
+go 1.14
+
+require (
+	github.com/hashicorp/go-version v1.2.1
+	github.com/koding/logging v0.0.0-20160720134017-8b5a689ed69b
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/koding/logging v0.0.0-20160720134017-8b5a689ed69b h1:Ix1hwcOtW6e0KG1+Fn1blMih1O4td/fa9Q2Br0/zPBo=
+github.com/koding/logging v0.0.0-20160720134017-8b5a689ed69b/go.mod h1:km9Clt+22fAbEvoPJSRufXDN110ZA6xLNU7oe4dwRHk=

--- a/parse_test.go
+++ b/parse_test.go
@@ -38,7 +38,7 @@ func TestParseRecordsAndData(t *testing.T) {
 		}
 
 		if ver != cas.ver {
-			t.Errorf("%d: got %q, want %q", ver, cas.ver)
+			t.Errorf("%d: got %q, want %q", i, ver, cas.ver)
 		}
 	}
 }


### PR DESCRIPTION
First of all, wonderful library!

This simple PR adds support for the `vagrant provision` command as well as the `--provision` flag that can be passed to `vagrant up`.

In order to be able to run tests, I had to fix one more issue and initialize a go module. If this is not fine, let me know.

Best, Roman